### PR TITLE
Add GitHub commits badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Team Project
+
+![Total Commits](https://img.shields.io/github/commits-since/Kravetsin/project-W3CanD01T/initial?style=for-the-badge)


### PR DESCRIPTION
Added a badge to display the total number of commits since the initial commit, improving project visibility and status tracking.